### PR TITLE
Fix dakrone theme

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -247,8 +247,12 @@
         'font-lock-comment-face))
      (when (fboundp 'epe-venv-p)
        (when (epe-venv-p)
-         (epe-colorize-with-face (concat "(" venv-current-name ") ") 'font-lock-comment-face)))
-     (epe-colorize-with-face (shrink-paths (split-string (pwd-repl-home (eshell/pwd)) "/"))
+         (epe-colorize-with-face (concat "(" venv-current-name ") ")
+                                 'font-lock-comment-face)))
+     (epe-colorize-with-face (funcall
+                              shrink-paths
+                              (split-string
+                               (funcall pwd-repl-home (eshell/pwd)) "/"))
                              'eshell-ls-directory-face)
      (when (epe-git-p)
        (concat
@@ -288,4 +292,3 @@
 (provide 'eshell-prompt-extras)
 
 ;;; eshell-prompt-extras.el ends here
-


### PR DESCRIPTION
I forgot that elisp is lisp-2 and can't call anonymously-bound functions
directly, it has to go through the `funcall` indirection.
