### PR TITLE
Fix detached head description

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -347,7 +347,7 @@ returns a string."
   (let ((branch (car (vc-git-branches))))
     (cond
      ((null branch) "no-branch")
-     ((string-match "^(HEAD detached at \\([[:word:]]+\\)" branch)
+     ((string-match "^(HEAD detached at \\(.+\\))$" branch)
       (concat epe-git-detached-HEAD-char (match-string 1 branch)))
      (t branch))))
 


### PR DESCRIPTION
When displaying a detached head, display the full tag. Otherwise, a tag like `v1.2.3` will display as `D:v1`.