### PR TITLE
Fix epe-sudo-symbol-face Inheritance

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -163,7 +163,9 @@
   :group 'epe)
 
 (defface epe-sudo-symbol-face
-  '((t (:inherit eshell-ls-unreadable-face)))
+  `((t (:inherit ,(if (facep 'eshell-ls-unreadable)
+                      'eshell-ls-unreadable
+                    'eshell-ls-unreadable-face))))
   "Face of your sudo symbol in prompt."
   :group 'epe)
 


### PR DESCRIPTION
Hi this PR fixes  `epe-sudo-symbol-face` in the case where `eshell-ls-unreadable-face` does not exist (basically a follow up to https://github.com/zwild/eshell-prompt-extras/pull/14).

Thanks!