### PR TITLE
Extended git information

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -173,7 +173,7 @@
   :group 'epe
   :type 'boolean)
 
-(defcustom epe-show-git-status-estended nil
+(defcustom epe-show-git-status-extended nil
   "A flag which indicates whether show extended git information."
   :group 'epe
   :type 'boolean)
@@ -712,7 +712,7 @@ The status is displayed on the last line."
    " "))
 
 (defun epe-git-prompt-info ()
-  (if epe-show-git-status-estended
+  (if epe-show-git-status-extended
       (epe-git-extended-info)
     (epe-git-default-info)))
 

--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -106,6 +106,46 @@
   :group 'epe
   :type 'string)
 
+(defcustom epe-git-modified-char "!"
+  "The character to show when the git repository has modified files."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-renamed-char "»"
+  "The character to show when the git repository has renamed files."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-deleted-char "x"
+  "The character to show when the git repository has deleted files."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-added-char "+"
+  "The character to show when the git repository has added files."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-unmerged-char "≠"
+  "The character to show when the git repository has unmerged files."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-ahead-char "↑"
+  "The character to show when the git repository has ahead commits."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-behind-char "↓"
+  "The character to show when the git repository has behind commits."
+  :group 'epe
+  :type 'string)
+
+(defcustom epe-git-diverged-char "↕"
+  "The character to show when the git repository has diverged commits."
+  :group 'epe
+  :type 'string)
+
 (defcustom epe-git-detached-HEAD-char "D:"
   "The character to show when the git repository is in detached HEAD state."
   :group 'epe
@@ -425,6 +465,38 @@ uncommitted changes, nil otherwise."
 
 (defvar epe-git-status
   "git status --porcelain -b 2> /dev/null")
+
+(defun epe-git-modified ()
+  "Return `epe-git-modified-char' if your git has modified files."
+  (and (epe-git-modified-p) epe-git-modified-char))
+
+(defun epe-git-renamed ()
+  "Return `epe-git-renamed-char' if your git has renamed files."
+  (and (epe-git-renamed-p) epe-git-renamed-char))
+
+(defun epe-git-deleted ()
+  "Return `epe-git-deleted-char' if your git has deleted files."
+  (and (epe-git-deleted-p) epe-git-deleted-char))
+
+(defun epe-git-added ()
+  "Return `epe-git-added-char' if your git has edded files."
+  (and (epe-git-added-p) epe-git-added-char))
+
+(defun epe-git-unmerged ()
+  "Return `epe-git-unmerged-char' if your git has unmerged files."
+  (and (epe-git-unmerged-p) epe-git-unmerged-char))
+
+(defun epe-git-ahead ()
+  "Return `epe-git-ahead-char' if your git has ahead commits."
+  (and (epe-git-ahead-p) epe-git-ahead-char))
+
+(defun epe-git-behind ()
+  "Return `epe-git-behind-char' if your git has behind commits."
+  (and (epe-git-behind-p) epe-git-behind-char))
+
+(defun epe-git-diverged ()
+  "Return `epe-git-diverged-char' if your git has diverged commits."
+  (and (epe-git-diverged-p) epe-git-diverged-char))
 
 (defun epe-git-p-helper (command)
   "Return if COMMAND has output."

--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -570,12 +570,7 @@ uncommitted changes, nil otherwise."
      (concat
       (epe-colorize-with-face ":" 'epe-dir-face)
       (epe-colorize-with-face
-       (concat (epe-git-branch)
-               (epe-git-dirty)
-               (epe-git-untracked)
-               (let ((unpushed (epe-git-unpushed-number)))
-                 (unless (= unpushed 0)
-                   (concat ":" (number-to-string unpushed)))))
+       (epe-git-default-info)
        'epe-git-face)))
    (epe-colorize-with-face " λ" (if (zerop eshell-last-command-status)
                                     'epe-success-face
@@ -625,11 +620,7 @@ uncommitted changes, nil otherwise."
        (concat
         (epe-colorize-with-face ":" 'epe-dir-face)
         (epe-colorize-with-face
-         (concat (epe-git-branch)
-                 (epe-git-dirty)
-                 (epe-git-untracked)
-                 (unless (= (epe-git-unpushed-number) 0)
-                   (concat ":" (number-to-string (epe-git-unpushed-number)))))
+         (epe-git-default-info)
          'epe-git-face)))
      (epe-colorize-with-face " λ" (if (zerop eshell-last-command-status)
                                       'epe-success-face
@@ -670,12 +661,7 @@ uncommitted changes, nil otherwise."
      (concat
       (epe-colorize-with-face ":" 'epe-dir-face)
       (epe-colorize-with-face
-       (concat (epe-git-branch)
-	       (epe-git-dirty)
-	       (epe-git-untracked)
-	       (let ((unpushed (epe-git-unpushed-number)))
-		 (unless (= unpushed 0)
-		   (concat ":" (number-to-string unpushed)))))
+       (epe-git-default-info)
        'epe-git-face)))
    (epe-colorize-with-face " λ" 'epe-symbol-face)
    (epe-colorize-with-face (if (= (user-uid) 0) "#" "") 'epe-sudo-symbol-face)
@@ -712,16 +698,20 @@ The status is displayed on the last line."
            (concat "/"
                    (epe-colorize-with-face git-component 'epe-git-dir-face)))
          (epe-colorize-with-face
-          (concat (or (epe-git-branch)
-                      (epe-git-tag))
-                  (epe-git-dirty)
-                  (epe-git-untracked)
-                  (let ((unpushed (epe-git-unpushed-number)))
-                    (unless (= unpushed 0)
-                      (concat ":" (number-to-string unpushed)))))
+          (epe-git-default-info)
           'epe-git-face)))))
    (epe-colorize-with-face "\n>" '(:weight bold))
    " "))
+
+(defun epe-git-default-info ()
+  "Default git information (epe prompt backwards compatibility)"
+  (concat (or (epe-git-branch)
+              (epe-git-tag))
+          (epe-git-dirty)
+          (epe-git-untracked)
+          (let ((unpushed (epe-git-unpushed-number)))
+            (unless (= unpushed 0)
+              (concat ":" (number-to-string unpushed))))))
 
 (provide 'eshell-prompt-extras)
 


### PR DESCRIPTION
Hi, 
this is an attempt to extend git information into the prompt by extending the functions that already existed in the code ('`epe-git-...-p`').
In order to maintain backwards compatibility the custom variable `epe-show-git-status-extended` (default `nil`) was introduced.

A note about the code: the previous git information was extracted to a dedicated function (`epe-git-default-info`) from all _themes_ but only in `epe-theme-multiline-with-status` the code differs for the additional 'git tag',  I don't know if it wanted but in this 'PR' the extracted function is used in all themes and contains the reference to git tag

Feel free to incorporate these changes and/or extract those you consider appropriate.
