### PR TITLE
Fix Python virtual environment name display

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -568,7 +568,7 @@ uncommitted changes, nil otherwise."
       'epe-remote-face))
    (let ((env-current-name (or (bound-and-true-p venv-current-name)
                                (bound-and-true-p conda-env-current-name))))
-     (when (and epe-show-python-info (bound-and-true-p env-current-name))
+     (when (and epe-show-python-info env-current-name)
        (epe-colorize-with-face (concat "(" env-current-name ") ") 'epe-venv-face)))
    (let ((f (cond ((eq epe-path-style 'fish) 'epe-fish-path)
                   ((eq epe-path-style 'single) 'epe-abbrev-dir-name)


### PR DESCRIPTION
Enabling lexical binding changed the behavior of `bound-and-true-p`.

`bound-and-true-p` used in line 571 now always returns `nil` and prevents Python virtual environment name from being displayed in the prompt.

This PR fixes the problem.