### PR TITLE
 xchanged detached head string

### DIFF
--- a/eshell-prompt-extras.el
+++ b/eshell-prompt-extras.el
@@ -426,7 +426,7 @@ returns a string."
   (let ((branch (car (vc-git-branches))))
     (cond
      ((null branch) "no-branch")
-     ((string-match "^(HEAD detached at \\(.+\\))$" branch)
+     ((string-match "^(HEAD detached at\\|from \\(.+\\))$" branch)
       (concat epe-git-detached-HEAD-char (match-string 1 branch)))
      (t branch))))
 


### PR DESCRIPTION
Hi, The output from `(vc-git-branches)` includes `(HEAD detached from <revision>)`. I have updated the search string to include the word from.